### PR TITLE
Add publisher for tf2 msgs demo

### DIFF
--- a/micro_ros_scripts/int32_publisher.py
+++ b/micro_ros_scripts/int32_publisher.py
@@ -1,14 +1,34 @@
+"""
+Usage
+
+Run agent:
+micro_ros_ws % ros2 run micro_ros_agent micro_ros_agent udp4 --port 2019 --verbose 6
+
+Run client:
+RMW_IMPLEMENTATION=rmw_microxrcedds ros2 run micro_ros_demos_rclc int32_subscriber
+
+Run publisher:
+ros2 run micro_ros_scripts int32_publisher --ros-args --param rate:=10.0
+"""
+
 import rclpy
+
 from rclpy.node import Node
+from rcl_interfaces.msg import ParameterDescriptor
 
 from std_msgs.msg import Int32
 
 
 class Int32Publisher(Node):
-    def __init__(self):
+    def __init__(self, rate):
         super().__init__("int32_publisher")
+
+        parameter_descriptor = ParameterDescriptor(description="Publish rate (Hz)")
+        self.declare_parameter("rate", 1.0, parameter_descriptor)
+        self.rate = self.get_parameter("rate").get_parameter_value().double_value
+
         self.publisher_ = self.create_publisher(Int32, "/std_msgs_msg_Int32", 10)
-        timer_period = 0.5  # seconds
+        timer_period = 1.0 / self.rate  # seconds
         self.timer = self.create_timer(timer_period, self.timer_callback)
         self.i = 0
 
@@ -16,14 +36,14 @@ class Int32Publisher(Node):
         msg = Int32()
         msg.data = self.i
         self.publisher_.publish(msg)
-        self.get_logger().info('Publishing: "%s"' % msg.data)
+        self.get_logger().info("Publishing: {}".format(msg))
         self.i += 1
 
 
 def main(args=None):
     rclpy.init(args=args)
 
-    int32_publisher = Int32Publisher()
+    int32_publisher = Int32Publisher(rate=1000)
 
     rclpy.spin(int32_publisher)
 

--- a/micro_ros_scripts/tfmessage_publisher.py
+++ b/micro_ros_scripts/tfmessage_publisher.py
@@ -1,0 +1,96 @@
+"""
+Usage
+
+Run agent:
+micro_ros_ws % ros2 run micro_ros_agent micro_ros_agent udp4 --port 2019 --verbose 6
+
+Run client:
+RMW_IMPLEMENTATION=rmw_microxrcedds ros2 run micro_ros_demos_rclc tfmessage_subscriber
+
+Run publisher:
+ros2 run micro_ros_scripts tfmessage_publisher --ros-args --param rate:=10.0
+"""
+
+import math
+import rclpy
+
+from rclpy.node import Node
+from rcl_interfaces.msg import ParameterDescriptor
+
+from transforms3d import euler
+
+from geometry_msgs.msg import Transform
+from geometry_msgs.msg import TransformStamped
+from tf2_msgs.msg import TFMessage
+
+
+class TFMessagePublisher(Node):
+    def __init__(self, rate):
+        super().__init__("tf_message_publisher")
+
+        parameter_descriptor = ParameterDescriptor(description="Publish rate (Hz)")
+        self.declare_parameter("rate", 1.0, parameter_descriptor)
+        self.rate = self.get_parameter("rate").get_parameter_value().double_value
+
+        self.publisher_ = self.create_publisher(
+            TFMessage, "/tf2_msgs_msg_TFMessage", 10
+        )
+        timer_period = 1.0 / self.rate  # seconds
+        self.timer = self.create_timer(timer_period, self.timer_callback)
+        self.x = 0.0
+        self.y = 0.25
+        self.z = 0.75
+        self.yaw_deg = 0.0
+
+    def timer_callback(self):
+        msg = TFMessage()
+
+        size = 50
+        for i in range(size):
+            x = self.x + 0.1 * i / size
+            y = self.y + 0.1 * i / size
+            z = self.z + 0.1 * i / size
+            yaw_deg = self.yaw_deg + 0.1 * i / size
+
+            yaw_rad = math.radians(yaw_deg)
+            q = euler.euler2quat(0.0, 0.0, yaw_rad, 'ryxz')
+
+            transform = Transform()
+            transform.translation.x = x
+            transform.translation.y = y
+            transform.translation.z = z
+            transform.rotation.x = q[1]
+            transform.rotation.y = q[2]
+            transform.rotation.z = q[3]
+            transform.rotation.w = q[0]
+
+            transform_stamped = TransformStamped()
+            transform_stamped.header.stamp = self.get_clock().now().to_msg()
+            # transform_stamped.header.frame_id = "iris"
+            transform_stamped.transform = transform
+
+            msg.transforms.append(transform_stamped)
+
+        self.x += 1.0
+        self.y += 1.0
+        self.z += 1.0
+        self.yaw_deg += 1.0
+
+        self.publisher_.publish(msg)
+        self.get_logger().info("Publishing: {}".format(msg))
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    tf_message_publisher = TFMessagePublisher(rate=1)
+
+    rclpy.spin(tf_message_publisher)
+
+    # Destroy the node prior to exit
+    tf_message_publisher.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/micro_ros_scripts/tfmessage_publisher.py
+++ b/micro_ros_scripts/tfmessage_publisher.py
@@ -66,7 +66,8 @@ class TFMessagePublisher(Node):
 
             transform_stamped = TransformStamped()
             transform_stamped.header.stamp = self.get_clock().now().to_msg()
-            # transform_stamped.header.frame_id = "iris"
+            transform_stamped.header.frame_id = "iris"
+            transform_stamped.child_frame_id = "iris/link[" + str(i) + "]"
             transform_stamped.transform = transform
 
             msg.transforms.append(transform_stamped)

--- a/micro_ros_scripts/transform_publisher.py
+++ b/micro_ros_scripts/transform_publisher.py
@@ -1,0 +1,76 @@
+"""
+Usage
+
+Run agent:
+micro_ros_ws % ros2 run micro_ros_agent micro_ros_agent udp4 --port 2019 --verbose 6
+
+Run client:
+RMW_IMPLEMENTATION=rmw_microxrcedds ros2 run micro_ros_demos_rclc transform_subscriber
+
+Run publisher:
+ros2 run micro_ros_scripts transform_publisher --ros-args --param rate:=10.0
+"""
+
+import math
+import rclpy
+
+from rclpy.node import Node
+from rcl_interfaces.msg import ParameterDescriptor
+
+from transforms3d import euler
+
+from geometry_msgs.msg import Transform
+
+
+class TransformPublisher(Node):
+    def __init__(self):
+        super().__init__("transform_publisher")
+
+        parameter_descriptor = ParameterDescriptor(description="Publish rate (Hz)")
+        self.declare_parameter("rate", 1.0, parameter_descriptor)
+        self.rate = self.get_parameter("rate").get_parameter_value().double_value
+
+        self.publisher_ = self.create_publisher(
+            Transform, "/geometry_msgs_msg_Transform", 10
+        )
+        timer_period = 1.0 / self.rate  # seconds
+        self.timer = self.create_timer(timer_period, self.timer_callback)
+        self.x = 0.0
+        self.y = 0.25
+        self.z = 0.75
+        self.yaw_deg = 0.0
+
+    def timer_callback(self):
+        yaw_rad = math.radians(self.yaw_deg)
+        q = euler.euler2quat(0.0, 0.0, yaw_rad, 'ryxz')
+
+        msg = Transform()
+        msg.translation.x = self.x
+        msg.translation.y = self.y
+        msg.translation.z = self.z
+        msg.rotation.x = q[1]
+        msg.rotation.y = q[2]
+        msg.rotation.z = q[3]
+        msg.rotation.w = q[0]
+        self.publisher_.publish(msg)
+        self.get_logger().info("Publishing: {}".format(msg))
+        self.x += 1.0
+        self.y += 1.0
+        self.z += 1.0
+        self.yaw_deg += 1.0
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    transform_publisher = TransformPublisher()
+
+    rclpy.spin(transform_publisher)
+
+    # Destroy the node prior to exit
+    transform_publisher.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/micro_ros_scripts/vector3_publisher.py
+++ b/micro_ros_scripts/vector3_publisher.py
@@ -1,0 +1,64 @@
+"""
+Usage
+
+Run agent:
+micro_ros_ws % ros2 run micro_ros_agent micro_ros_agent udp4 --port 2019 --verbose 6
+
+Run client:
+RMW_IMPLEMENTATION=rmw_microxrcedds ros2 run micro_ros_demos_rclc vector3_subscriber
+
+Run publisher:
+ros2 run micro_ros_scripts vector3_publisher --ros-args --param rate:=10.0
+"""
+
+import rclpy
+
+from rclpy.node import Node
+from rcl_interfaces.msg import ParameterDescriptor
+
+from geometry_msgs.msg import Vector3
+
+
+class Vector3Publisher(Node):
+    def __init__(self):
+        super().__init__("vector3_publisher")
+
+        parameter_descriptor = ParameterDescriptor(description="Publish rate (Hz)")
+        self.declare_parameter("rate", 1.0, parameter_descriptor)
+        self.rate = self.get_parameter("rate").get_parameter_value().double_value
+
+        self.publisher_ = self.create_publisher(
+            Vector3, "/geometry_msgs_msg_Vector3", 10
+        )
+        timer_period = 1.0 / self.rate  # seconds
+        self.timer = self.create_timer(timer_period, self.timer_callback)
+        self.x = 0.0
+        self.y = 0.25
+        self.z = 0.75
+
+    def timer_callback(self):
+        msg = Vector3()
+        msg.x = self.x
+        msg.y = self.y
+        msg.z = self.z
+        self.publisher_.publish(msg)
+        self.get_logger().info("Publishing: {}".format(msg))
+        self.x += 1.0
+        self.y += 1.0
+        self.z += 1.0
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    vector3_publisher = Vector3Publisher()
+
+    rclpy.spin(vector3_publisher)
+
+    # Destroy the node prior to exit
+    vector3_publisher.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     entry_points={
         'console_scripts': [
             'int32_publisher = micro_ros_scripts.int32_publisher:main',
+            'transform_publisher = micro_ros_scripts.transform_publisher:main',
             'vector3_publisher = micro_ros_scripts.vector3_publisher:main',
         ],
     },

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     entry_points={
         'console_scripts': [
             'int32_publisher = micro_ros_scripts.int32_publisher:main',
+            'tfmessage_publisher = micro_ros_scripts.tfmessage_publisher:main',
             'transform_publisher = micro_ros_scripts.transform_publisher:main',
             'vector3_publisher = micro_ros_scripts.vector3_publisher:main',
         ],

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     entry_points={
         'console_scripts': [
             'int32_publisher = micro_ros_scripts.int32_publisher:main',
+            'vector3_publisher = micro_ros_scripts.vector3_publisher:main',
         ],
     },
 )


### PR DESCRIPTION
Add example publisher for a tf2_msgs/msg/TFMessage

For use with this branch of micro-ROS-demos:

- https://github.com/srmainwaring/micro-ROS-demos/tree/wips/wip-tf2-msgs-demo

Run the micro-ROS agent:

```bash
ros2 run micro_ros_agent micro_ros_agent udp4 --port 2019 --verbose 6
```

Run the micro-ROS subscriber:

```bash
RMW_IMPLEMENTATION=rmw_microxrcedds ros2 run micro_ros_demos_rclc tfmessage_subscriber
```

Publish a TFMessage containing 50 transforms at 100 Hz:

```bash
ros2 run micro_ros_scripts tfmessage_publisher --ros-args --param rate:=100.0
```

## Other examples

- std_msgs/msg/Int32
- geometry_msgs/msg/Vector3
- geometry_msgs/msg/Transform